### PR TITLE
fixed typo in package name

### DIFF
--- a/test-engine/README.md
+++ b/test-engine/README.md
@@ -5,7 +5,7 @@ This library is a layer on top of the `scrypto-unit` library to make writing tes
 To use the library, add the following dev dependency to the `Cargo.toml` file
 ```
 [dev-dependencies]
-test_engine = { git = "https://github.com/BeakerFi/scrypto-toolkit", branch = "main"}
+test-engine = { git = "https://github.com/BeakerFi/scrypto-toolkit", branch = "main"}
 ```
 
 # Features


### PR DESCRIPTION
Usage instructions weren't working due to typo in the package name.
One character fix.